### PR TITLE
Use field.to_python to do django type conversions on the field before ch...

### DIFF
--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -9,7 +9,7 @@ class DirtyFieldsMixin(object):
         reset_state(sender=self.__class__, instance=self)
 
     def _as_dict(self):
-        return dict([(f.name, getattr(self, f.name)) for f in self._meta.local_fields if not f.rel])
+        return dict([(f.name, f.to_python(getattr(self, f.name))) for f in self._meta.local_fields if not f.rel])
     
     def get_dirty_fields(self):
         new_state = self._as_dict()


### PR DESCRIPTION
...ecking if dirty.

This solves issues where you might have a decimal field that you write a string to, eg:
>>> m = MyModel.objects.get(id=1)
>>> m.my_decimal_field
Decimal('1.00')
>>> m.my_decimal_field = u'1.00' # from a form or something
>>> m.is_dirty() # currently evaluates to True, should evaluate to False
False

This pull request could probably use some unit testing, but it should be safe as the base class for django fields defines to_python as:

def to_python(self, value):
  return value

So, any field type that does not have an explicit to_python method will behave as before this change.