### PR TITLE
Copying Dirty Fields

### DIFF
--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -6,17 +6,23 @@ from django.db.models.signals import post_save
 class DirtyFieldsMixin(object):
     def __init__(self, *args, **kwargs):
         super(DirtyFieldsMixin, self).__init__(*args, **kwargs)
-        post_save.connect(reset_state, sender=self.__class__,
-                        dispatch_uid='%s-DirtyFieldsMixin-sweeper' % self.__class__.__name__)
+        post_save.connect(reset_state,
+                          sender=self.__class__,
+                          dispatch_uid='{}-DirtyFieldsMixin-sweeper'.format(
+                              self.__class__.__name__))
         reset_state(sender=self.__class__, instance=self)
 
     def _as_dict(self):
-        return dict([(f.name, getattr(self, f.name)) for f in self._meta.local_fields if not f.rel])
+        return dict([(f.name, getattr(self, f.name))
+                     for f in self._meta.local_fields
+                     if not f.rel])
 
     def get_dirty_fields(self):
         new_state = self._as_dict()
 
-        return dict([(key, value) for key, value in self._original_state.items() if value != new_state[key]])
+        return dict([(key, value)
+                     for key, value in self._original_state.items()
+                     if value != new_state[key]])
 
     def is_dirty(self):
         # in order to be dirty we need to have been saved at least once, so we


### PR DESCRIPTION
The dirty fields mixin works fine for simple types like string, booleans or integers, however it fails when it comes to more complex objects like geometries or JSON fields.

Take the following model

```python
class Test(models.Model):
    anchor = PointField()
```

Then do something like

```python
t = Test.objects.get(id=1)
t.anchor.x = 42
t.get_dirty_fields()
```

In the current version, this returns an empty array. However with the attached patch, it will indeed return "anchor" as a changed field, with the correct previous value.

Technical choices for this patch are explained in details in efd0286.

There is also a bit of PEP8 formatting in 6b4dcee.