### PR TITLE
Fixing dirty field tracking of mutable values

### DIFF
--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -1,4 +1,5 @@
 # Adapted from http://stackoverflow.com/questions/110803/dirty-fields-in-django
+from copy import copy
 
 from django.db.models.signals import post_save
 
@@ -11,7 +12,7 @@ class DirtyFieldsMixin(object):
         reset_state(sender=self.__class__, instance=self)
 
     def _as_dict(self):
-        return dict([(f.name, getattr(self, f.name)) for f in self._meta.local_fields if not f.rel])
+        return dict([(f.name, copy(getattr(self, f.name))) for f in self._meta.local_fields if not f.rel])
 
     def get_dirty_fields(self):
         new_state = self._as_dict()


### PR DESCRIPTION
When using a model field which allows mutable values (such as JSONField), dirty field tracking won't work without at least a shallow copy of the object.