### PR TITLE
Add travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ script:
   - python runtests.py
 
 install:
-- pip install -r requirements.pip
+- pip install django-dirtyfields

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+
+python:
+  - "2.6"
+  - "2.7"
+
+script:
+  - python run_tests.py
+
+install:
+- pip install -r requirements.pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "2.7"
 
 script:
-  - python run_tests.py
+  - python runtests.py
 
 install:
 - pip install -r requirements.pip

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+import os
+import sys
+
+import django
+from django.conf import settings
+from django.test.utils import get_runner
+
+if __name__ == "__main__":
+    os.environ['DJANGO_SETTINGS_MODULE'] = 'example_app.settings'
+    django.setup()
+    TestRunner = get_runner(settings)
+    test_runner = TestRunner()
+    failures = test_runner.run_tests(["example_app.testing_app.tests"])
+    sys.exit(bool(failures))


### PR DESCRIPTION
Adding travis configuration file, and a runtests.py script to launch reusable application tests (https://docs.djangoproject.com/en/1.7/topics/testing/advanced/#using-the-django-test-runner-to-test-reusable-applications).

TODO: test different django versions.

Related Issue: #15 