### PR TITLE
fixing occasional KeyError issue when calling instance.get_dirty_fields

### DIFF
--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -3,6 +3,7 @@
 from django.db.models.signals import post_save
 from django.forms.models import model_to_dict
 
+
 class DirtyFieldsMixin(object):
     def __init__(self, *args, **kwargs):
         super(DirtyFieldsMixin, self).__init__(*args, **kwargs)
@@ -34,6 +35,9 @@ class DirtyFieldsMixin(object):
         all_modify_field = {}
 
         for key, value in new_state.iteritems():
+            if key not in self._original_state:
+                continue
+
             original_value = self._original_state[key]
             if value != original_value:
                 all_modify_field[key] = original_value


### PR DESCRIPTION
when calling .get_dirty_fields with check_relationship=False, I encounter occasional KeyError issues (under Django 1.6.5) for some specific model fields that are present in self._as_dict() but not in  self._original_state. This issue does not appear with using self._full_dict() instead.