### PR TITLE
Fix check relationship regression bug

### DIFF
--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -1,7 +1,7 @@
 # Adapted from http://stackoverflow.com/questions/110803/dirty-fields-in-django
 
 from django.db.models.signals import post_save
-from django.forms.models import model_to_dict
+
 
 class DirtyFieldsMixin(object):
     def __init__(self, *args, **kwargs):
@@ -12,8 +12,6 @@ class DirtyFieldsMixin(object):
                 name=self.__class__.__name__))
         reset_state(sender=self.__class__, instance=self)
 
-    def _full_dict(self):
-        return model_to_dict(self)
     def _as_dict(self, check_relationship):
         all_field = {}
 
@@ -27,12 +25,9 @@ class DirtyFieldsMixin(object):
         return all_field
 
     def get_dirty_fields(self, check_relationship=False):
-        if check_relationship:
-            # We want to check every field, including foreign keys and
-            # one-to-one fields,
-            new_state = self._full_dict()
-        else:
-            new_state = self._as_dict()
+        # check_relationship indicates whether we want to check for foreign keys
+        # and one-to-one fields or ignore them
+        new_state = self._as_dict(check_relationship)
         all_modify_field = {}
 
         for key, value in new_state.iteritems():

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -46,4 +46,6 @@ class DirtyFieldsMixin(object):
 
 
 def reset_state(sender, instance, **kwargs):
-    instance._original_state = instance._full_dict()
+    # original state should hold all posible dirty fields to avoid
+    # getting a `KeyError` when checking if a field is dirty or not
+    instance._original_state = instance._as_dict(check_relationship=True)

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -14,13 +14,15 @@ class DirtyFieldsMixin(object):
 
     def _full_dict(self):
         return model_to_dict(self)
-
-    def _as_dict(self):
+    def _as_dict(self, check_relationship):
         all_field = {}
 
         for field in self._meta.local_fields:
-            if not field.rel:
-                all_field[field.name] = getattr(self, field.name)
+
+            if field.rel and not check_relationship:
+                continue
+
+            all_field[field.name] = getattr(self, field.name)
 
         return all_field
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -14,3 +14,10 @@ class TestModelWithForeignKey(DirtyFieldsMixin, models.Model):
 
 class TestModelWithOneToOneField(DirtyFieldsMixin, models.Model):
     o2o = models.OneToOneField(TestModel)
+
+
+class TestModelWithNonEditableFields(DirtyFieldsMixin, models.Model):
+    dt = models.DateTimeField(auto_now_add=True)
+    characters = models.CharField(blank=True, max_length=80,
+                                  editable=False)
+    boolean = models.BooleanField(default=True)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -70,7 +70,7 @@ class DirtyFieldsMixinTestCase(TestCase):
             'o2o': tm1
         })
 
-    def test_dirty_fields_ignores_the_editable_property_of_fileds(self):
+    def test_dirty_fields_ignores_the_editable_property_of_fields(self):
         # Non regression test case for bug:
         # https://github.com/smn/django-dirtyfields/issues/17
         tm = TestModelWithNonEditableFields.objects.create()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -48,7 +48,7 @@ class DirtyFieldsMixinTestCase(TestCase):
 
         # But if we use 'check_relationships' param, then we have to.
         self.assertEqual(tm.get_dirty_fields(check_relationship=True), {
-            'fkey': tm1.id
+            'fkey': tm1
         })
 
     def test_relationship_option_for_one_to_one_field(self):
@@ -65,5 +65,5 @@ class DirtyFieldsMixinTestCase(TestCase):
 
         # But if we use 'check_relationships' param, then we have to.
         self.assertEqual(tm.get_dirty_fields(check_relationship=True), {
-            'o2o': tm1.id
+            'o2o': tm1
         })


### PR DESCRIPTION
Populate the original state of the model with all fields (including foreign keys fields), so that when trying to  check for dirty fields no `KeyError` is thrown.

Tests pass, and it seems to me that they are correct.

Fixes #17 