### PR TITLE
Fix missing related objects regression bug

### DIFF
--- a/src/dirtyfields/__init__.py
+++ b/src/dirtyfields/__init__.py
@@ -1,2 +1,2 @@
 from __future__ import absolute_import
-from dirtyfields.dirtyfields import DirtyFieldsMixin
+from .dirtyfields import DirtyFieldsMixin

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -27,6 +27,13 @@ class DirtyFieldsMixin(object):
 
         return all_field
 
+    def get_ForeignKey_dirtyfield(self, field):
+        try:
+            value = getattr(self, field.name)
+        except ObjectDoesNotExist:
+            value = None
+        return value
+
     def _get_dirtyfield_getter(self, field):
         cls = field.__class__
         for klass in (cls,) + cls.__bases__:

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -1,5 +1,6 @@
 # Adapted from http://stackoverflow.com/questions/110803/dirty-fields-in-django
 
+from django.core.exceptions import ObjectDoesNotExist
 from django.db.models.signals import post_save
 
 
@@ -18,7 +19,10 @@ class DirtyFieldsMixin(object):
         for field in self._meta.local_fields:
             if field.rel and not check_relationship:
                 continue
-            all_field[field.name] = getattr(self, field.name)
+            try:
+                all_field[field.name] = getattr(self, field.name)
+            except ObjectDoesNotExist:
+                all_field[field.name] = None
 
         return all_field
 

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -19,16 +19,28 @@ class DirtyFieldsMixin(object):
         for field in self._meta.local_fields:
             if field.rel and not check_relationship:
                 continue
-            try:
+            getter = self._get_dirtyfield_getter(field)
+            if getter:
+                all_field[field.name] = getattr(self, getter)(field)
+            else:
                 all_field[field.name] = getattr(self, field.name)
-            except ObjectDoesNotExist:
-                all_field[field.name] = None
 
         return all_field
 
+    def _get_dirtyfield_getter(self, field):
+        cls = field.__class__
+        for klass in (cls,) + cls.__bases__:
+            getter_name = 'get_{}_dirtyfield'.format(klass.__name__)
+            if hasattr(self, getter_name):
+                break
+        else:
+            getter_name = False
+
+        return getter_name
+
     def get_dirty_fields(self, check_relationship=False):
-        # check_relationship indicates whether we want to check for foreign keys
-        # and one-to-one fields or ignore them
+        # check_relationship indicates whether we want to check for
+        # foreign keys and one-to-one fields or ignore them
         new_state = self._as_dict(check_relationship)
         all_modify_field = {}
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from dirtyfields import DirtyFieldsMixin
+from src.dirtyfields.dirtyfields import DirtyFieldsMixin
 
 
 class TestModel(DirtyFieldsMixin, models.Model):

--- a/tests/models.py
+++ b/tests/models.py
@@ -2,6 +2,10 @@ from django.db import models
 from src.dirtyfields.dirtyfields import DirtyFieldsMixin
 
 
+class MyForeignKey(models.ForeignKey):
+    pass
+
+
 class TestModel(DirtyFieldsMixin, models.Model):
     """A simple test model to test dirty fields mixin with"""
     boolean = models.BooleanField(default=True)
@@ -10,6 +14,13 @@ class TestModel(DirtyFieldsMixin, models.Model):
 
 class TestModelWithForeignKey(DirtyFieldsMixin, models.Model):
     fkey = models.ForeignKey(TestModel)
+
+
+class TestModelWithCustomForeignKey(DirtyFieldsMixin, models.Model):
+    fkey = MyForeignKey(TestModel)
+
+    def get_MyForeignKey_dirtyfield(self, field):
+        return 'foo'
 
 
 class TestModelWithOneToOneField(DirtyFieldsMixin, models.Model):

--- a/tests/models.py
+++ b/tests/models.py
@@ -16,6 +16,10 @@ class TestModelWithOneToOneField(DirtyFieldsMixin, models.Model):
     o2o = models.OneToOneField(TestModel)
 
 
+class TestModelWithManyToManyField(DirtyFieldsMixin, models.Model):
+    m2m = models.ManyToManyField(TestModel)
+
+
 class TestModelWithNonEditableFields(DirtyFieldsMixin, models.Model):
     dt = models.DateTimeField(auto_now_add=True)
     characters = models.CharField(blank=True, max_length=80,

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,7 +1,7 @@
 from django.db import IntegrityError
 from django.test import TestCase
-from models import (TestModel, TestModelWithForeignKey,
-                    TestModelWithManyToManyField,
+from models import (TestModel, TestModelWithCustomForeignKey,
+                    TestModelWithForeignKey, TestModelWithManyToManyField,
                     TestModelWithNonEditableFields, TestModelWithOneToOneField)
 
 
@@ -104,6 +104,27 @@ class DirtyFieldsMixinTestCase(TestCase):
         # https://github.com/smn/django-dirtyfields/issues/26
         self.assertRaises(IntegrityError,
                           TestModelWithForeignKey.objects.create)
+
+    def test_mandatory_foreign_key_field_initialized_is_tracked_propertly(self):
+        # Non regression test case for bug:
+        # https://github.com/smn/django-dirtyfields/issues/26
+        tm1 = TestModel.objects.create()
+        tm2 = TestModel.objects.create()
+        tm = TestModelWithForeignKey.objects.create(fkey=tm1)
+        tm.fkey = tm2
+        self.assertEqual(tm.get_dirty_fields(check_relationship=False), {})
+        self.assertEqual(tm.get_dirty_fields(check_relationship=True), {
+            'fkey': tm1
+        })
+
+    def test_custom_get_dirty_fields_is_called_for_custom_field_classes(self):
+        tm1 = TestModel.objects.create()
+        tm2 = TestModel.objects.create()
+        tm = TestModelWithCustomForeignKey.objects.create(fkey=tm1)
+        self.assertEqual(tm._original_state['fkey'], 'foo')
+        tm.fkey = tm2
+        # never dirty since the custom method always returns 'foo'
+        self.assertFalse(tm.is_dirty(check_relationship=True))
 
     def test_dirty_fields_is_harmless_when_using_many_to_many_fields(self):
         tm1 = TestModel.objects.create()


### PR DESCRIPTION
Another approach to fix #26 
Basically captures the `ObjectDoesNotExist` exception and setting that field to None.
Took some ideas from romgar's branch.
