### PR TITLE
Added a pass on related fields that do not yet exist.

### DIFF
--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -1,6 +1,7 @@
 # Adapted from http://stackoverflow.com/questions/110803/dirty-fields-in-django
 
 from django.db.models.signals import post_save
+from django.core.exceptions import ObjectDoesNotExist
 
 
 class DirtyFieldsMixin(object):
@@ -18,7 +19,10 @@ class DirtyFieldsMixin(object):
         for field in self._meta.local_fields:
             if field.rel and not check_relationship:
                 continue
-            all_field[field.name] = getattr(self, field.name)
+            try:
+                all_field[field.name] = getattr(self, field.name)
+            except ObjectDoesNotExist:
+                pass        
 
         return all_field
 


### PR DESCRIPTION
I was having an issue with this where a child class was throwing an exception after instantiation because the parent did not yet exist.

If you have any thoughts on how this could go wrong, or if there might be a better approach, please feel free to comment.