### PR TITLE
Preventing dirtyfields to evaluate field value if its a django db expression

### DIFF
--- a/src/dirtyfields/compat.py
+++ b/src/dirtyfields/compat.py
@@ -1,0 +1,10 @@
+
+def is_db_expression(value):
+    try:
+        # django < 1.8
+        from django.db.models.expressions import ExpressionNode
+        return isinstance(value, ExpressionNode)
+    except ImportError:
+        # django >= 1.8  (big refactoring in Lookup/Expressions/Transforms)
+        from django.db.models.expressions import BaseExpression, Combinable
+        return isinstance(value, (BaseExpression, Combinable))

--- a/src/dirtyfields/dirtyfields.py
+++ b/src/dirtyfields/dirtyfields.py
@@ -1,6 +1,7 @@
 # Adapted from http://stackoverflow.com/questions/110803/dirty-fields-in-django
 
 from django.db.models.signals import post_save
+from .compat import is_db_expression
 
 
 class DirtyFieldsMixin(object):
@@ -21,6 +22,11 @@ class DirtyFieldsMixin(object):
                     continue
 
             field_value = getattr(self, field.attname)
+
+            # If current field value is an expression, we are not evaluating it
+            if is_db_expression(field_value):
+                continue
+
             all_field[field.name] = field.to_python(field_value)
 
         return all_field

--- a/tests/models.py
+++ b/tests/models.py
@@ -42,3 +42,7 @@ class OrdinaryTestModelWithForeignKey(models.Model):
 
 class SubclassModel(TestModel):
     pass
+
+
+class TestExpressionModel(DirtyFieldsMixin, models.Model):
+    counter = models.IntegerField(default=0)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 from django.test.utils import override_settings
 from .models import (TestModel, TestModelWithForeignKey, TestModelWithNonEditableFields, TestModelWithOneToOneField,
                      OrdinaryTestModel, OrdinaryTestModelWithForeignKey, TestModelWithSelfForeignKey,
-                     SubclassModel, TestModelWithDecimalField)
+                     SubclassModel, TestModelWithDecimalField, TestExpressionModel)
 
 
 class DirtyFieldsMixinTestCase(TestCase):
@@ -212,3 +212,14 @@ class DirtyFieldsMixinTestCase(TestCase):
 
         tm.decimal_field = u"2.00"
         self.assertFalse(tm.is_dirty())
+
+    def test_expressions_not_taken_into_account_for_dirty_check(self):
+        # Non regression test case for bug:
+        # https://github.com/smn/django-dirtyfields/issues/39
+        from django.db.models import F
+        tm = TestExpressionModel.objects.create()
+        tm.counter = F('counter') + 1
+
+        # This save() was raising a ValidationError: [u"'F(counter) + Value(1)' value must be an integer."]
+        # caused by a call to_python() on an expression node
+        tm.save()


### PR DESCRIPTION
Also adding a compat file, as expressions have been refactored in django 1.8
Aim to fix #39 