### PR TITLE
Add travis coverage for django14 by avoiding python3 testing in that case

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,21 @@
 language: python
 
 python:
-  - "2.7"
-  - "3.4"
+  - 2.7
+  - 3.4
+
+env:
+  - TOXENV=django14
+  - TOXENV=django15
+  - TOXENV=django16
+  - TOXENV=django17
+  - TOXENV=django18
+  - TOXENV=coverage
+
+matrix:
+  exclude:
+    - python: 3.4
+      env: TOXENV=django14
 
 script:
   - tox
@@ -13,7 +26,7 @@ install:
   - pip install -e .
 
 after_success:
-  - coveralls
+  - if test "$TOXENV" = "coverage"; then coveralls; fi
 
 deploy:
   provider: pypi

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = django15,django16,django17,django18,coverage
+envlist = django14,django15,django16,django17,django18,coverage
 
 [testenv]
 commands = py.test
@@ -7,6 +7,11 @@ deps =
     pytest
     pytest-django
     jsonfield==1.0.3
+
+[testenv:django14]
+deps =
+    django>=1.4,<1.4.99
+    {[testenv]deps}
 
 [testenv:django15]
 deps =


### PR DESCRIPTION
Django 1.4 was not tested because it was not supporting python3.
But with travis `matrix` option, we can exclude non compatible situations, like this one.